### PR TITLE
AJS-14300: Update project files and package references

### DIFF
--- a/WebPush.Test/WebPush.Test.csproj
+++ b/WebPush.Test/WebPush.Test.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net471;net48;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net471;net48;netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WebPush/WebPush.csproj
+++ b/WebPush/WebPush.csproj
@@ -1,30 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net462;net471;net48;netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.12</Version>
-    <Authors>Cory Thompson</Authors>
-    <Company />
-    <Product />
-    <Description>Web Push library for C#</Description>
-    <PackageLicenseUrl>https://github.com/web-push-libs/web-push-csharp/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/web-push-libs/web-push-csharp/</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/web-push-libs/web-push-csharp/</RepositoryUrl>
-    <PackageTags>web push notifications vapid</PackageTags>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net462;net471;net48;netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Version>1.0.1</Version>
+		<Authors>Cory Thompson</Authors>
+		<Company />
+		<Product />
+		<Description>Web Push library for C#</Description>
+		<PackageId>o2Smart.WebPush</PackageId>
+		<PackageLicenseUrl>https://github.com/ACJUSA/web-push-csharp/blob/master/LICENSE</PackageLicenseUrl>
+		<PackageProjectUrl>https://github.com/ACJUSA/web-push-csharp/</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/ACJUSA/web-push-csharp/</RepositoryUrl>
+		<PackageTags>web push notifications vapid</PackageTags>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net471' OR '$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="System.Text.Json" Version="8.0.1"  Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net471' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'"/>
-  </ItemGroup>
+	<ItemGroup>
+		<Reference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net471' OR '$(TargetFramework)' == 'net48'" />
+		<PackageReference Include="System.Text.Json" Version="9.0.0" Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net471' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Upgraded package versions in `WebPush.Test.csproj`.
- Removed `net5.0` from `TargetFrameworks`.
- Changed `Version` from `1.0.12` to `1.0.1` in `WebPush.csproj`.
- Added `PackageId` as `o2Smart.WebPush`.
- Updated URLs to point to a new GitHub repository.
- Removed `netstandard2.1` from `TargetFrameworks`.
- Replaced `Portable.BouncyCastle` with `BouncyCastle.Cryptography` (v2.5.1).
- Updated `Microsoft.SourceLink.GitHub` to v8.0.0.
- Updated `System.Text.Json` to v9.0.0.